### PR TITLE
Create ocipkg image for Windows

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -33,18 +33,22 @@ jobs:
 
       # Deploy to GitHub container reigstry (ghcr.io)
       - name: Install ocipkg-cli
+        if: github.event_name != 'pull_request'
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: ocipkg-cli --version=~0.2
       - name: Add path
+        if: github.event_name != 'pull_request'
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         run: |
           ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
 
       - name: Push oci-archives
+        if: github.event_name != 'pull_request'
         run: |
           ocipkg push mkl-static-lp64-seq.tar
           ocipkg push mkl-static-lp64-iomp.tar
@@ -70,16 +74,20 @@ jobs:
 
       # Deploy to GitHub container reigstry (ghcr.io)
       - uses: actions-rs/cargo@v1
+        if: github.event_name != 'pull_request'
         name: Install ocipkg-cli
         with:
           command: install
           args: ocipkg-cli --version=~0.2
       - name: Add path
+        if: github.event_name != 'pull_request'
         run: echo "$HOME/.cargo/bin" >> $Env:GITHUB_PATH
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         run: |
           ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
       - name: Push oci-archives
+        if: github.event_name != 'pull_request'
         run: |
           ocipkg push mkl-static-lp64-seq.tar
           ocipkg push mkl-static-lp64-iomp.tar

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -19,7 +19,21 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: actions-rs/cargo@v1
+      # Create oci-archive
+      - name: Install Intel MKL
+        run: |
+          apt update
+          apt install -y cpio
+          ./install-mkl.sh
+      - name: Create oci-archive using intel-mkl-pack
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --release
+
+      # Deploy to GitHub container reigstry (ghcr.io)
+      - name: Install ocipkg-cli
+        uses: actions-rs/cargo@v1
         with:
           command: install
           args: ocipkg-cli --version=~0.2
@@ -27,44 +41,47 @@ jobs:
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         run: |
           ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
 
-      - name: Install Intel MKL
-        run: |
-          apt update
-          apt install -y cpio
-          ./install-mkl.sh
-
-      - name: Create oci-archive using intel-mkl-pack
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --release
-
       - name: Push oci-archives
-        if: github.event_name != 'pull_request'
-        run: >-
-          for ar in $(find . -name "mkl-*-*-*.tar"); do
-            ocipkg push $ar;
-          done
+        run: |
+          ocipkg push mkl-static-lp64-seq.tar
+          ocipkg push mkl-static-lp64-iomp.tar
+          ocipkg push mkl-static-ilp64-seq.tar
+          ocipkg push mkl-static-ilp64-iomp.tar
 
   windows:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v1
+
+      # Create oci-archive
       - name: Get MKL using NuGet
         run: |
           nuget install intelmkl.devel.cluster.win-x64  -Version 2022.0.3.171
           nuget install intelmkl.static.cluster.win-x64 -Version 2022.0.3.171
-      - name: Add DLL runtime path
-        run: |
-          echo "${{ github.workspace }}/intelmkl.redist.win-x64.2022.0.3.171/runtimes/win-x64/native" >> $Env:GITHUB_PATH
-          echo "${{ github.workspace }}/intelopenmp.redist.win.2022.0.0.3663/runtimes/win-x64/native" >> $Env:GITHUB_PATH
       - uses: actions-rs/cargo@v1
         with:
           command: run
           args: --release
         env:
           MKLROOT: ${{ github.workspace }}
+
+      # Deploy to GitHub container reigstry (ghcr.io)
+      - uses: actions-rs/cargo@v1
+        name: Install ocipkg-cli
+        with:
+          command: install
+          args: ocipkg-cli --version=~0.2
+      - name: Add path
+        run: echo "$HOME/.cargo/bin" >> $Env:GITHUB_PATH
+      - name: Login to GitHub Container Registry
+        run: |
+          ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
+      - name: Push oci-archives
+        run: |
+          ocipkg push mkl-static-lp64-seq.tar
+          ocipkg push mkl-static-lp64-iomp.tar
+          ocipkg push mkl-static-ilp64-seq.tar
+          ocipkg push mkl-static-ilp64-iomp.tar

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -49,3 +49,22 @@ jobs:
           for ar in $(find . -name "mkl-*-*-*.tar"); do
             ocipkg push $ar;
           done
+
+  windows:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get MKL using NuGet
+        run: |
+          nuget install intelmkl.devel.cluster.win-x64  -Version 2022.0.3.171
+          nuget install intelmkl.static.cluster.win-x64 -Version 2022.0.3.171
+      - name: Add DLL runtime path
+        run: |
+          echo "${{ github.workspace }}/intelmkl.redist.win-x64.2022.0.3.171/runtimes/win-x64/native" >> $Env:GITHUB_PATH
+          echo "${{ github.workspace }}/intelopenmp.redist.win.2022.0.0.3663/runtimes/win-x64/native" >> $Env:GITHUB_PATH
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --release
+        env:
+          MKLROOT: ${{ github.workspace }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,6 @@ use std::{
     time::Instant,
 };
 
-const REGISTRY: &str = "ghcr.io/rust-math/rust-mkl";
-
 fn main() -> Result<()> {
     let run_id: u64 = std::env::var("GITHUB_RUN_ID")
         .unwrap_or_else(|_| "0".to_string()) // fallback value for local testing
@@ -27,8 +25,12 @@ fn main() -> Result<()> {
         let lib = Library::new(cfg)?;
         let (year, _, update) = lib.version()?;
         let name = ImageName::parse(&format!(
-            "{}/{}:{}.{}-{}",
-            REGISTRY, cfg, year, update, run_id
+            "ghcr.io/rust-math/rust-mkl/{}/{}:{}.{}-{}",
+            std::env::consts::OS,
+            cfg,
+            year,
+            update,
+            run_id
         ))?;
         let output = format!("{}.tar", cfg);
 


### PR DESCRIPTION
intel-mkl-tool 0.8.0 can find oneAPI-distributed MKL on Windows. This PR uses it as it is.